### PR TITLE
Sort query results before returning them

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ edit = "0.1"
 crossterm = "0.27.0"
 ratatui = "0.26"
 opener = "0.6"
-itertools = "0.14.0"
 # Dependencies for the GUI
 egui = "0.28"
 eframe = "0.28"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ edit = "0.1"
 crossterm = "0.27.0"
 ratatui = "0.26"
 opener = "0.6"
+itertools = "0.14.0"
 # Dependencies for the GUI
 egui = "0.28"
 eframe = "0.28"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,7 @@ use clap::{command, value_parser, Arg};
 use ftag::{
     core::{self, get_all_tags, search, untracked_files, Error},
     load::get_store_path,
-    query::{count_files_tags, run_query, DenseTagTable},
+    query::{count_files_tags, run_query, run_query_sorted, DenseTagTable},
 };
 use std::path::PathBuf;
 
@@ -30,12 +30,15 @@ fn main() -> Result<(), Error> {
         return Ok(());
     }
     if let Some(matches) = matches.subcommand_matches(cmd::QUERY) {
-        run_query(
-            current_dir,
-            matches
-                .get_one::<String>(arg::FILTER)
-                .ok_or(Error::InvalidArgs)?,
-        )
+        let filter = matches
+            .get_one::<String>(arg::FILTER)
+            .ok_or(Error::InvalidArgs)?;
+
+        if let Some(true) = matches.get_one(arg::SORTED) {
+            run_query_sorted(current_dir, filter)
+        } else {
+            run_query(current_dir, filter)
+        }
     } else if let Some(matches) = matches.subcommand_matches(cmd::SEARCH) {
         return search(
             current_dir,
@@ -154,6 +157,14 @@ fn parse_args() -> clap::ArgMatches {
                         .required(true)
                         .help(about::QUERY_FILTER)
                         .long_help(about::QUERY_FILTER_LONG),
+                )
+                .arg(
+                    Arg::new(arg::SORTED)
+                        .long("sorted")
+                        .short('s')
+                        .num_args(0)
+                        .help(about::QUERY_SORTED)
+                        .long_help(about::QUERY_SORTED_LONG),
                 ),
         )
         .subcommand(
@@ -226,6 +237,7 @@ mod arg {
     pub const PATH: &str = "path"; // --path flag to run in a different path than cwd.
     pub const SEARCH_STR: &str = "search string";
     pub const BASH_COMPLETE_WORDS: &str = "bash-complete-words";
+    pub const SORTED: &str = "sorted"; // --sorted flag for query command to sort results
 }
 
 mod about {
@@ -240,6 +252,8 @@ tags 'foo' and 'bar'.  More complex queries can be delimited using
 parentheses. For example: '(foo & bar) | !baz' will list all files
 that either have both 'foo' and 'bar' tags, or don't have the 'baz'
 tag.";
+    pub const QUERY_SORTED: &str = "Sort query results before outputting.";
+    pub const QUERY_SORTED_LONG: &str = "After applying the filter, sort all results alphabetically by filename before outputting them.";
     pub const SEARCH: &str = "Search all tags and descriptions for the given keywords";
     pub const SEARCH_STR: &str = "A string of keywords to search for.";
     pub const SEARCH_STR_LONG: &str = "Any file that contains any of the keywords in this string in either it's tags or description will included in the output.";

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::{command, value_parser, Arg};
+use clap::{command, value_parser, Arg, ArgAction};
 use ftag::{
     core::{self, get_all_tags, search, untracked_files, Error},
     load::get_ftag_path,
@@ -165,7 +165,7 @@ fn parse_args() -> clap::ArgMatches {
                     Arg::new(arg::SORTED)
                         .long("sorted")
                         .short('s')
-                        .num_args(0)
+                        .action(ArgAction::SetTrue)
                         .help(about::QUERY_SORTED)
                         .long_help(about::QUERY_SORTED_LONG),
                 ),

--- a/src/query.rs
+++ b/src/query.rs
@@ -228,6 +228,15 @@ pub fn run_query(dirpath: PathBuf, filter: &str) -> Result<(), Error> {
     Ok(())
 }
 
+pub fn run_query_sorted(dirpath: PathBuf, filter: &str) -> Result<(), Error> {
+    let table = TagTable::from_dir(dirpath)?;
+    let filter = Filter::<usize>::parse(filter, &table).map_err(Error::InvalidFilter)?;
+    for path in table.query_sorted(filter) {
+        println!("{}", path);
+    }
+    Ok(())
+}
+
 /// 2d array of bools.
 pub(crate) struct BoolTable {
     data: Box<[bool]>, // Cannot be resized by accident.

--- a/src/query.rs
+++ b/src/query.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use itertools::Itertools;
 
 /// Tries to set the flag at the given index. If the index is outside the bounds
 /// of the vector, the vector is automatically resized. That is what makes it
@@ -76,12 +77,13 @@ pub(crate) struct TagTable {
 
 impl TagTable {
     fn query(&self, filter: Filter<usize>) -> impl Iterator<Item = std::path::Display<'_>> {
-        self.table.iter().filter_map(move |(path, flags)| {
-            if filter.eval(flags) {
-                Some(path.display())
-            } else {
-                None
-            }
+        // Filter before sorting so we're doing a little less work
+        let filtered = self.table.iter().filter(move |(_, flags)| {
+            filter.eval(flags)
+        });
+        let sorted = Itertools::sorted(filtered);
+        sorted.map(move |(path, _)| {
+            path.display()
         })
     }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -9,7 +9,6 @@ use crate::{
 };
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use itertools::Itertools;
 
 /// Tries to set the flag at the given index. If the index is outside the bounds
 /// of the vector, the vector is automatically resized. That is what makes it
@@ -77,13 +76,12 @@ pub(crate) struct TagTable {
 
 impl TagTable {
     fn query(&self, filter: Filter<usize>) -> impl Iterator<Item = std::path::Display<'_>> {
-        // Filter before sorting so we're doing a little less work
-        let filtered = self.table.iter().filter(move |(_, flags)| {
-            filter.eval(flags)
-        });
-        let sorted = Itertools::sorted(filtered);
-        sorted.map(move |(path, _)| {
-            path.display()
+        self.table.iter().filter_map(move |(path, flags)| {
+            if filter.eval(flags) {
+                Some(path.display())
+            } else {
+                None
+            }
         })
     }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -86,13 +86,12 @@ impl TagTable {
     }
 
     fn query_sorted(&self, filter: Filter<usize>) -> impl Iterator<Item = std::path::Display<'_>> {
-        let filtered = self.table
+        let mut results: Vec<_> = self.table
             .iter()
-            .filter(move |(_, flags)| filter.eval(flags));
-
-        let mut collected = Vec::from_iter(filtered);
-        collected.sort();
-        collected.into_iter().map(move |(path, _)| {
+            .filter(move |(_, flags)| filter.eval(flags))
+            .collect();
+        results.sort();
+        results.into_iter().map(|(path, _)| {
             path.display()
         })
     }

--- a/src/query.rs
+++ b/src/query.rs
@@ -85,6 +85,18 @@ impl TagTable {
         })
     }
 
+    fn query_sorted(&self, filter: Filter<usize>) -> impl Iterator<Item = std::path::Display<'_>> {
+        let filtered = self.table
+            .iter()
+            .filter(move |(_, flags)| filter.eval(flags));
+
+        let mut collected = Vec::from_iter(filtered);
+        collected.sort();
+        collected.into_iter().map(move |(path, _)| {
+            path.display()
+        })
+    }
+
     /// Create a new tag table by recursively traversing directories
     /// from `dirpath`.
     pub(crate) fn from_dir(dirpath: PathBuf) -> Result<Self, Error> {

--- a/src/query.rs
+++ b/src/query.rs
@@ -86,14 +86,13 @@ impl TagTable {
     }
 
     fn query_sorted(&self, filter: Filter<usize>) -> impl Iterator<Item = std::path::Display<'_>> {
-        let mut results: Vec<_> = self.table
+        let mut results: Vec<_> = self
+            .table
             .iter()
             .filter(move |(_, flags)| filter.eval(flags))
             .collect();
         results.sort();
-        results.into_iter().map(|(path, _)| {
-            path.display()
-        })
+        results.into_iter().map(|(path, _)| path.display())
     }
 
     /// Create a new tag table by recursively traversing directories


### PR DESCRIPTION
This PR is more opinionated than the other one I've made, so I especially understand if you don't want to accept it.

I noticed that the results of `ftag query` were in arbitrary order, so I find myself always piping the results into `sort` since the default ordering  doesn't group items in the same subdirectory with each other.

The only place I could do the sorting was in TagTable's `query`, since it can only return unsortable `Display<'_>` items. To minimize the amount of work being done, I broke it up so we apply the filter before attempting to do any sorting.