### PR TITLE
Minor performance improvement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ path = "src/gui.rs"
 strip = true # Automatically strip symbols
 panic = "abort" # Don't unwind stack. Should never panic.
 codegen-units = 1
+lto = true
 
 [profile.release-with-debug]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ftag"
-version = "0.4.2"
+version = "0.4.4"
 edition = "2021"
 authors = ["Ranjeeth Mahankali <ranjeethmahankali@gmail.com>"]
 description = "CLI tool for tagging and searching files. See README.md for more info."

--- a/src/load.rs
+++ b/src/load.rs
@@ -146,11 +146,10 @@ impl GlobMatches {
              * to match it as a glob. I have tested with and without this
              * optimization, and it makes a significant difference.
              */
-            for (fi, f) in files.iter().enumerate() {
-                if OsStr::new(g.path) == f.name() {
-                    row[fi] = true;
-                    continue 'globs;
-                }
+            let gpath = OsStr::new(g.path);
+            if let Ok(fi) = files.binary_search_by(move |f| f.name().cmp(gpath)) {
+                row[fi] = true;
+                continue 'globs;
             }
             for (fi, f) in files.iter().enumerate() {
                 if glob_match(g.path.as_bytes(), f.name().as_encoded_bytes()) {

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -11,27 +11,6 @@ pub(crate) enum DirEntryType {
     Dir,
 }
 
-/// Implementing sort means that among the entries of a directory, the
-/// nested directories will be at the start and the files will be at
-/// the end.
-impl PartialOrd for DirEntryType {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for DirEntryType {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        use std::cmp::Ordering::*;
-        match (self, other) {
-            (DirEntryType::File, DirEntryType::File) => Equal,
-            (DirEntryType::File, DirEntryType::Dir) => Greater,
-            (DirEntryType::Dir, DirEntryType::File) => Less,
-            (DirEntryType::Dir, DirEntryType::Dir) => Equal,
-        }
-    }
-}
-
 /// Entry found during recursive traversal. `depth` 1 corresponds to
 /// the root of the recursive traversal, and subsequent depths
 /// indicate the level of nesting.
@@ -125,7 +104,12 @@ impl WalkDirectories {
                     }
                     self.num_children = self.stack.len() - before;
                     let children = &mut self.stack[before..];
-                    children.sort_by_key(|d| d.entry_type);
+                    children.sort_by(|a, b| match (a.entry_type, b.entry_type) {
+                        (DirEntryType::File, DirEntryType::File) => a.name.cmp(&b.name),
+                        (DirEntryType::File, DirEntryType::Dir) => std::cmp::Ordering::Greater,
+                        (DirEntryType::Dir, DirEntryType::File) => std::cmp::Ordering::Less,
+                        (DirEntryType::Dir, DirEntryType::Dir) => std::cmp::Ordering::Equal,
+                    });
                     let children = &self.stack[(self.stack.len() - numfiles)..];
                     return Some((depth, &self.cur_path, children));
                 }


### PR DESCRIPTION
Squeezing out ever so slightly more performance, by pre-sorting the list of files and binary searching through them. In theory this is only an improvement when most of the entries are filenames instead of globs. In practice this is true, and the performance improvement is tangible.

Closes #27 .