### PR TITLE
Performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ftag"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 authors = ["Ranjeeth Mahankali <ranjeethmahankali@gmail.com>"]
 description = "CLI tool for tagging and searching files. See README.md for more info."

--- a/src/query.rs
+++ b/src/query.rs
@@ -146,8 +146,8 @@ impl TagTable {
             }
             // Process all files in the directory.
             gmatcher.find_matches(children, &files, false);
-            for (ci, cpath) in children.iter().enumerate() {
-                if let Some(cpath) = get_relative_path(curpath, cpath.name(), &table.root) {
+            for (ci, child) in children.iter().enumerate() {
+                if let Some(cpath) = get_relative_path(curpath, child.name(), &table.root) {
                     filetags.clear();
                     let mut found: bool = false;
                     for fi in gmatcher.matched_globs(ci) {

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,5 +1,5 @@
 use crate::{
-    core::{get_relative_path, Error},
+    core::Error,
     filter::{Filter, TagMaker},
     load::{
         get_filename_str, get_ftag_path, implicit_tags_str, DirData, FileLoadingOptions,
@@ -120,7 +120,7 @@ impl TagTable {
                 file_desc: false,
             },
         ));
-        while let Some((depth, curpath, children)) = walker.next() {
+        while let Some((depth, curpath, relpath, children)) = walker.next() {
             inherited.update(depth)?;
             let DirData {
                 tags,
@@ -147,17 +147,29 @@ impl TagTable {
             // Process all files in the directory.
             gmatcher.find_matches(children, &files, false);
             for (ci, child) in children.iter().enumerate() {
-                if let Some(cpath) = get_relative_path(curpath, child.name(), &table.root) {
-                    filetags.clear();
-                    let mut found: bool = false;
-                    for fi in gmatcher.matched_globs(ci) {
-                        found = true;
-                        filetags.extend(files[fi].tags.iter().map(|t| t.to_string()));
-                        filetags.extend(implicit_tags_str(get_filename_str(&cpath)?));
-                    }
-                    if found {
-                        table.add_file(cpath, &mut filetags, &mut num_tags, &inherited.tag_indices);
-                    }
+                filetags.clear();
+                let mut found: bool = false;
+                for fi in gmatcher.matched_globs(ci) {
+                    found = true;
+                    filetags.extend(files[fi].tags.iter().map(|t| t.to_string()));
+                    filetags.extend(implicit_tags_str(
+                        child
+                            .name()
+                            .to_str()
+                            .ok_or(Error::InvalidPath(child.name().into()))?,
+                    ));
+                }
+                if found {
+                    table.add_file(
+                        {
+                            let mut relpath = relpath.to_path_buf();
+                            relpath.push(child.name());
+                            relpath
+                        },
+                        &mut filetags,
+                        &mut num_tags,
+                        &inherited.tag_indices,
+                    );
                 }
             }
         }

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -77,8 +77,9 @@ impl WalkDirectories {
                     if let Ok(entries) = std::fs::read_dir(&self.cur_path) {
                         for child in entries.flatten() {
                             let cname = child.file_name();
-                            let cnamestr = cname.to_str().unwrap_or("");
-                            if cnamestr == FTAG_FILE || cnamestr == FTAG_BACKUP_FILE {
+                            if cname == OsStr::new(FTAG_FILE)
+                                || cname == OsStr::new(FTAG_BACKUP_FILE)
+                            {
                                 continue;
                             }
                             match child.file_type() {

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -54,9 +54,9 @@ impl WalkDirectories {
         })
     }
 
-    /// Move on to the next directory. Returns a tuple containing the
-    /// depth of the directory, its path, and a slice containing info
-    /// about the files in this directory.
+    /// Move on to the next directory. Returns a tuple containing the depth of
+    /// the directory, its absolute path, its path relative to the root of the
+    /// walk, and a slice containing info about the files in this directory.
     pub(crate) fn next(&mut self) -> Option<(usize, &Path, &Path, &[DirEntry])> {
         while let Some(DirEntry {
             depth,

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -30,6 +30,7 @@ impl DirEntry {
 /// about the contents of the directory. The traversal is depth first.
 pub(crate) struct WalkDirectories {
     cur_path: PathBuf,
+    rel_path: PathBuf,
     stack: Vec<DirEntry>,
     cur_depth: usize,
     num_children: usize,
@@ -42,6 +43,7 @@ impl WalkDirectories {
         }
         Ok(WalkDirectories {
             cur_path: dirpath,
+            rel_path: PathBuf::new(),
             stack: vec![DirEntry {
                 depth: 1,
                 entry_type: DirEntryType::Dir,
@@ -55,7 +57,7 @@ impl WalkDirectories {
     /// Move on to the next directory. Returns a tuple containing the
     /// depth of the directory, its path, and a slice containing info
     /// about the files in this directory.
-    pub(crate) fn next(&mut self) -> Option<(usize, &Path, &[DirEntry])> {
+    pub(crate) fn next(&mut self) -> Option<(usize, &Path, &Path, &[DirEntry])> {
         while let Some(DirEntry {
             depth,
             entry_type,
@@ -67,9 +69,11 @@ impl WalkDirectories {
                 DirEntryType::Dir => {
                     while self.cur_depth > depth - 1 {
                         self.cur_path.pop();
+                        self.rel_path.pop();
                         self.cur_depth -= 1;
                     }
-                    self.cur_path.push(name);
+                    self.cur_path.push(name.clone());
+                    self.rel_path.push(name);
                     self.cur_depth += 1;
                     // Push all children.
                     let mut numfiles = 0;
@@ -112,7 +116,7 @@ impl WalkDirectories {
                         (DirEntryType::Dir, DirEntryType::Dir) => std::cmp::Ordering::Equal,
                     });
                     let children = &self.stack[(self.stack.len() - numfiles)..];
-                    return Some((depth, &self.cur_path, children));
+                    return Some((depth, &self.cur_path, &self.rel_path, children));
                 }
             }
         }


### PR DESCRIPTION
The current CPU bottleneck was in `get_relative_path`, which calls `.strip_prefix` on a path.  This is silly because the directory walker is already walking the directory tree, and is well positioned to provide the relative path without recomputing the relative path by removing a prefix.

This PR removes this bottleneck, and removes the `get_relative_path` function. This improved the performance by around 10% on my large photo archive.

The next bottleneck is in parsing the `.ftag` files. The time is being spent looking for occurrences of `[` and `]`.