### PR TITLE
Faster parsing with aho-corasick

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["command-line-utilities"]
 [dependencies]
 clap = { version = "4.5.26", features = ["cargo"] }
 fast-glob = "0.4.3"
+aho-corasick = "1.1.3"
 edit = "0.1.5"
 crossterm = "0.28.1"
 ratatui = "0.29.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ftag"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2021"
 authors = ["Ranjeeth Mahankali <ranjeethmahankali@gmail.com>"]
 description = "CLI tool for tagging and searching files. See README.md for more info."

--- a/src/load.rs
+++ b/src/load.rs
@@ -1,3 +1,7 @@
+use crate::{
+    core::{Error, FTAG_BACKUP_FILE, FTAG_FILE},
+    walk::DirEntry,
+};
 use aho_corasick::{AhoCorasick, Match};
 use fast_glob::glob_match;
 use std::{
@@ -7,11 +11,6 @@ use std::{
     ops::Range,
     path::{Path, PathBuf},
     sync::LazyLock,
-};
-
-use crate::{
-    core::{Error, FTAG_BACKUP_FILE, FTAG_FILE},
-    walk::DirEntry,
 };
 
 /// Try to infer a range of years from the name of a document or file.

--- a/src/load.rs
+++ b/src/load.rs
@@ -265,7 +265,7 @@ impl LoaderOptions {
 
 static AC_PARSER: LazyLock<AhoCorasick> = LazyLock::new(|| {
     const HEADER_STR: [&str; 3] = ["[path]", "[tags]", "[desc]"];
-    AhoCorasick::new(&HEADER_STR).expect("FATAL: Unable to initialize the parser")
+    AhoCorasick::new(HEADER_STR).expect("FATAL: Unable to initialize the parser")
 });
 
 enum HeaderType {
@@ -458,7 +458,7 @@ impl Loader {
                                 filepath.to_path_buf(),
                                 "FATAL: Error when searching for headers in the file.".into(),
                             ))?;
-                            content = &input[header.end..n.start].trim();
+                            content = input[header.end..n.start].trim();
                             (content, Some(n))
                         }
                         None => (input[header.end..].trim(), None),

--- a/src/load.rs
+++ b/src/load.rs
@@ -299,12 +299,6 @@ impl Loader {
             .map_err(|_| Error::CannotReadStoreFile(filepath.to_path_buf()))?
             .read_to_string(&mut self.raw_text)
             .map_err(|_| Error::CannotReadStoreFile(filepath.to_path_buf()))?;
-        let mut tags: Vec<&str> = Vec::new();
-        let mut desc: Option<&str> = None;
-        let mut files: Vec<FileData<'a>> = Vec::new();
-        // We store the data of the file we're currently parsing as:
-        // (list of globs, list of tags, optional description).
-        let mut curfile: Option<(Vec<&'a str>, Vec<&'a str>, Option<&'a str>)> = None;
         let mut input = self.raw_text.trim();
         if !input.starts_with('[') {
             return Err(Error::CannotParseFtagFile(
@@ -312,6 +306,12 @@ impl Loader {
                 "File does not begin with a header.".into(),
             ));
         }
+        let mut tags: Vec<&str> = Vec::new();
+        let mut desc: Option<&str> = None;
+        let mut files: Vec<FileData<'a>> = Vec::new();
+        // We store the data of the file we're currently parsing as:
+        // (list of globs, list of tags, optional description).
+        let mut curfile: Option<(Vec<&'a str>, Vec<&'a str>, Option<&'a str>)> = None;
         while let Some(start) = input.find('[') {
             // Walk the text one header at a time.
             let start = start + 1;


### PR DESCRIPTION
This PR speeds up the parsing of the ftag file by 3.5%, by using the `aho-corasick` crate to parse the `.ftag` file. The CPU bottlenecks are almost non-existent at this point and the gains are diminishing to almost nothing.

Loading the the .ftag file on one thread and processing the parsed data in another thread concurrently might be the way to try and further optimize performance, but that might get very complex.