### PR TITLE
Faster Hashing and Other Performance Improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ categories = ["command-line-utilities"]
 clap = { version = "4.5.26", features = ["cargo"] }
 fast-glob = "0.4.3"
 aho-corasick = "1.1.3"
+ahash = "0.8.11"
 edit = "0.1.5"
 crossterm = "0.28.1"
 ratatui = "0.29.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ftag"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2021"
 authors = ["Ranjeeth Mahankali <ranjeethmahankali@gmail.com>"]
 description = "CLI tool for tagging and searching files. See README.md for more info."

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -77,7 +77,9 @@ fn main() -> Result<(), Error> {
         }
         return Ok(());
     } else if let Some(_matches) = matches.subcommand_matches(cmd::TAGS) {
-        println!("{}", get_all_tags(current_dir)?.join("\n"));
+        for tag in get_all_tags(current_dir)? {
+            println!("{}", tag);
+        }
         return Ok(());
     } else {
         return Err(Error::InvalidArgs);
@@ -132,7 +134,7 @@ fn handle_bash_completions(current_dir: PathBuf, mut words: Vec<&str>) {
                     let last = if last == 0 { last } else { last + 1 };
                     (&word[..last], &word[last..])
                 };
-                for tag in tags.iter().filter(|t| t.starts_with(right)) {
+                for tag in tags.filter(|t| t.starts_with(right)) {
                     println!("{left}{}", tag);
                 }
             }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -75,18 +75,11 @@ fn main() -> Result<(), Error> {
             println!("{}", path.display());
         }
         return Ok(());
-    } else if let Some(matches) = matches.subcommand_matches(cmd::TAGS) {
-        if let Some(true) = matches.get_one(arg::SORTED) {
-            let mut tags: Box<[String]> = get_all_tags(current_dir)?.collect();
-            println!("Sorting tags");
-            tags.sort();
-            for tag in tags {
-                println!("{}", tag);
-            }
-        } else {
-            for tag in get_all_tags(current_dir)? {
-                println!("{}", tag);
-            }
+    } else if let Some(_matches) = matches.subcommand_matches(cmd::TAGS) {
+        let mut tags: Box<[String]> = get_all_tags(current_dir)?.collect();
+        tags.sort();
+        for tag in tags {
+            println!("{}", tag);
         }
         return Ok(());
     } else {
@@ -223,16 +216,7 @@ fn parse_args() -> clap::ArgMatches {
         )
         .subcommand(clap::Command::new(cmd::CLEAN).about(about::CLEAN))
         .subcommand(clap::Command::new(cmd::UNTRACKED).about(about::UNTRACKED))
-        .subcommand(
-            clap::Command::new(cmd::TAGS).about(about::TAGS).arg(
-                Arg::new(arg::SORTED)
-                    .long("sorted")
-                    .short('s')
-                    .action(ArgAction::SetTrue)
-                    .help(about::TAGS_SORTED)
-                    .long_help(about::TAGS_SORTED_LONG),
-            ),
-        )
+        .subcommand(clap::Command::new(cmd::TAGS).about(about::TAGS))
         .subcommand(
             clap::Command::new(cmd::BASH_COMPLETE)
                 .arg(Arg::new(arg::BASH_COMPLETE_WORDS).num_args(3)),
@@ -278,8 +262,6 @@ that either have both 'foo' and 'bar' tags, or don't have the 'baz'
 tag.";
     pub const QUERY_SORTED: &str = "Sort query results before outputting.";
     pub const QUERY_SORTED_LONG: &str = "After applying the filter, sort all results alphabetically by filename before outputting them.";
-    pub const TAGS_SORTED: &str = "Sort the tags before outputting.";
-    pub const TAGS_SORTED_LONG: &str = "The tags are sorted before they're printed to the terminal. This may incur a slight increase in memory ussage and performance.";
     pub const SEARCH: &str = "Search all tags and descriptions for the given keywords";
     pub const SEARCH_STR: &str = "A string of keywords to search for.";
     pub const SEARCH_STR_LONG: &str = "Any file that contains any of the keywords in this string in either it's tags or description will included in the output.";

--- a/src/core.rs
+++ b/src/core.rs
@@ -6,8 +6,8 @@ use crate::{
     },
     walk::{DirWalker, VisitedDir},
 };
+use ahash::AHashSet;
 use std::{
-    collections::HashSet,
     fmt::Debug,
     fs::OpenOptions,
     io,
@@ -436,7 +436,7 @@ pub fn untracked_files(root: PathBuf) -> Result<Vec<PathBuf>, Error> {
 
 /// Recursively traverse the directories from `path` and get all tags.
 pub fn get_all_tags(path: PathBuf) -> Result<impl Iterator<Item = String>, Error> {
-    let mut alltags: HashSet<String> = HashSet::new();
+    let mut alltags: AHashSet<String> = AHashSet::new();
     // let mut alltags: Vec<String> = Vec::new();
     let mut walker = DirWalker::new(path)?;
     let mut loader = Loader::new(LoaderOptions::new(

--- a/src/core.rs
+++ b/src/core.rs
@@ -94,8 +94,8 @@ pub fn check(path: PathBuf) -> Result<(), Error> {
     ));
     let mut missing: Vec<GlobInfo> = Vec::new();
     while let Some(VisitedDir {
-        abs_dir,
-        rel_dir,
+        abs_path: abs_dir,
+        rel_path: rel_dir,
         files,
         ..
     }) = walker.next()
@@ -192,7 +192,7 @@ pub fn clean(path: PathBuf) -> Result<(), Error> {
         },
     ));
     let mut valid: Vec<FileDataOwned> = Vec::new();
-    while let Some(VisitedDir { abs_dir, files, .. }) = walker.next() {
+    while let Some(VisitedDir { abs_path: abs_dir, files, .. }) = walker.next() {
         let (path, DirData { globs, desc, tags }) = {
             match get_ftag_path::<true>(abs_dir) {
                 Some(path) => {
@@ -400,8 +400,8 @@ pub fn untracked_files(root: PathBuf) -> Result<Vec<PathBuf>, Error> {
         },
     ));
     while let Some(VisitedDir {
-        abs_dir,
-        rel_dir,
+        abs_path: abs_dir,
+        rel_path: rel_dir,
         files,
         ..
     }) = walker.next()
@@ -447,7 +447,7 @@ pub fn get_all_tags(path: PathBuf) -> Result<impl Iterator<Item = String>, Error
             file_desc: false,
         },
     ));
-    while let Some(VisitedDir { abs_dir, .. }) = walker.next() {
+    while let Some(VisitedDir { abs_path: abs_dir, .. }) = walker.next() {
         let DirData {
             mut tags,
             mut globs,
@@ -507,7 +507,7 @@ pub fn search(path: PathBuf, needle: &str) -> Result<(), Error> {
             None => false,
         }
     };
-    while let Some(VisitedDir { abs_dir, .. }) = walker.next() {
+    while let Some(VisitedDir { abs_path: abs_dir, .. }) = walker.next() {
         let DirData { tags, globs, desc } = {
             match get_ftag_path::<true>(abs_dir) {
                 Some(path) => loader.load(&path)?,

--- a/src/core.rs
+++ b/src/core.rs
@@ -7,6 +7,7 @@ use crate::{
     walk::{DirWalker, VisitedDir},
 };
 use std::{
+    collections::HashSet,
     fmt::Debug,
     fs::OpenOptions,
     io,
@@ -434,8 +435,9 @@ pub fn untracked_files(root: PathBuf) -> Result<Vec<PathBuf>, Error> {
 }
 
 /// Recursively traverse the directories from `path` and get all tags.
-pub fn get_all_tags(path: PathBuf) -> Result<Vec<String>, Error> {
-    let mut alltags: Vec<String> = Vec::new();
+pub fn get_all_tags(path: PathBuf) -> Result<impl Iterator<Item = String>, Error> {
+    let mut alltags: HashSet<String> = HashSet::new();
+    // let mut alltags: Vec<String> = Vec::new();
     let mut walker = DirWalker::new(path)?;
     let mut loader = Loader::new(LoaderOptions::new(
         true,
@@ -471,9 +473,7 @@ pub fn get_all_tags(path: PathBuf) -> Result<Vec<String>, Error> {
             );
         }
     }
-    alltags.sort();
-    alltags.dedup();
-    Ok(alltags)
+    Ok(alltags.into_iter())
 }
 
 pub fn search(path: PathBuf, needle: &str) -> Result<(), Error> {

--- a/src/core.rs
+++ b/src/core.rs
@@ -423,8 +423,10 @@ pub fn untracked_files(root: PathBuf) -> Result<Vec<PathBuf>, Error> {
                 }
             }
         };
-        matcher.find_matches(&files, &globs, false);
+        matcher.find_matches(files, &globs, false);
         untracked.extend(files.iter().enumerate().filter_map(|(fi, file)| {
+            // Skip the files that matched with at least one glob. Copy the
+            // paths of files that didn't match with any glob.
             match matcher.matched_globs(fi).next() {
                 Some(_) => None,
                 None => {

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,4 +1,3 @@
-use crate::query::safe_get_flag;
 use std::fmt::{Debug, Display};
 
 pub enum FilterParseError {
@@ -69,7 +68,7 @@ impl<T: TagData> Filter<T> {
 impl Filter<usize> {
     pub fn eval(&self, flags: &[bool]) -> bool {
         match self {
-            Tag(ti) => safe_get_flag(flags, *ti),
+            Tag(ti) => *flags.get(*ti).unwrap_or(&false),
             And(lhs, rhs) => lhs.eval(flags) && rhs.eval(flags),
             Or(lhs, rhs) => lhs.eval(flags) || rhs.eval(flags),
             Not(input) => !input.eval(flags),

--- a/src/load.rs
+++ b/src/load.rs
@@ -165,7 +165,7 @@ impl GlobMatches {
 
     /// For a given file at `file_index`, get indices of all globs
     /// that matched the file.
-    pub fn matched_globs(&self, file_index: usize) -> impl Iterator<Item = usize> + '_ {
+    pub fn matched_globs(&self, file_index: usize) -> impl Iterator<Item = usize> + use<'_> {
         (0..self.num_globs).filter(move |gi| self.row(*gi)[file_index])
     }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -121,8 +121,8 @@ impl TagTable {
         ));
         while let Some(VisitedDir {
             depth,
-            abs_dir,
-            rel_dir,
+            abs_path: abs_dir,
+            rel_path: rel_dir,
             files,
         }) = walker.next()
         {

--- a/src/query.rs
+++ b/src/query.rs
@@ -20,12 +20,6 @@ fn safe_set_flag(flags: &mut Vec<bool>, index: usize) {
     flags[index] = true;
 }
 
-/// Read the flag at the given index in the slice. If the index is outside the
-/// bounds false is returned safely.
-pub(crate) fn safe_get_flag(flags: &[bool], index: usize) -> bool {
-    *flags.get(index).unwrap_or(&false)
-}
-
 /*
 When a tags are specified for a folder, it's subfolders and all their subfolders
 inherit those tags. This inheritance follows the directory tree. When

--- a/src/query.rs
+++ b/src/query.rs
@@ -182,7 +182,7 @@ impl TagTable {
     fn add_file(&mut self, path: PathBuf, tags: &mut Vec<String>, inherited: &Vec<usize>) {
         let flags = self.table.entry(path).or_default();
         // Set the file's explicit tags.
-        flags.reserve(flags.len() + tags.len());
+        flags.reserve(tags.len());
         for tag in tags.drain(..) {
             safe_set_flag(flags, Self::get_tag_index(tag, &mut self.tag_index_map));
         }

--- a/src/query.rs
+++ b/src/query.rs
@@ -147,18 +147,17 @@ impl TagTable {
             gmatcher.find_matches(files, &globs, false);
             for (ci, child) in files.iter().enumerate() {
                 filetags.clear();
-                let mut found: bool = false;
-                for fi in gmatcher.matched_globs(ci) {
-                    found = true;
-                    filetags.extend(globs[fi].tags.iter().map(|t| t.to_string()));
+                let found = gmatcher.matched_globs(ci).fold(false, |_, gi| {
+                    filetags.extend(globs[gi].tags.iter().map(|t| t.to_string()));
+                    true
+                });
+                if found {
                     filetags.extend(implicit_tags_str(
                         child
                             .name()
                             .to_str()
                             .ok_or(Error::InvalidPath(child.name().into()))?,
                     ));
-                }
-                if found {
                     table.add_file(
                         {
                             let mut relpath = rel_dir.to_path_buf();

--- a/src/query.rs
+++ b/src/query.rs
@@ -182,7 +182,6 @@ impl TagTable {
     fn add_file(&mut self, path: PathBuf, tags: &mut Vec<String>, inherited: &Vec<usize>) {
         let flags = self.table.entry(path).or_default();
         // Set the file's explicit tags.
-        flags.reserve(inherited.len() + tags.len());
         for tag in tags.drain(..) {
             safe_set_flag(flags, Self::get_tag_index(tag, &mut self.tag_index_map));
         }


### PR DESCRIPTION
* Speed up the construction of TagTable with a faster non cryptographic hashmap. This results in a marginal speed up of all CLI commands that construct a tag table.
* Speed up the the `tags` command using a `HashSet`.