### PR TITLE
More Performance Improvements

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -77,7 +77,7 @@ fn main() -> Result<(), Error> {
         return Ok(());
     } else if let Some(_matches) = matches.subcommand_matches(cmd::TAGS) {
         let mut tags: Box<[String]> = get_all_tags(current_dir)?.collect();
-        tags.sort();
+        tags.sort_unstable();
         for tag in tags {
             println!("{}", tag);
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,8 @@
-use clap::{command, value_parser, Arg, ArgAction};
+use clap::{command, value_parser, Arg};
 use ftag::{
     core::{self, get_all_tags, search, untracked_files, Error},
     load::get_ftag_path,
-    query::{count_files_tags, run_query, run_query_sorted, DenseTagTable},
+    query::{count_files_tags, run_query, DenseTagTable},
 };
 use std::path::PathBuf;
 
@@ -33,11 +33,7 @@ fn main() -> Result<(), Error> {
         let filter = matches
             .get_one::<String>(arg::FILTER)
             .ok_or(Error::InvalidArgs)?;
-        if let Some(true) = matches.get_one(arg::SORTED) {
-            run_query_sorted(current_dir, filter)
-        } else {
-            run_query(current_dir, filter)
-        }
+        run_query(current_dir, filter)
     } else if let Some(matches) = matches.subcommand_matches(cmd::SEARCH) {
         return search(
             current_dir,
@@ -163,14 +159,6 @@ fn parse_args() -> clap::ArgMatches {
                         .required(true)
                         .help(about::QUERY_FILTER)
                         .long_help(about::QUERY_FILTER_LONG),
-                )
-                .arg(
-                    Arg::new(arg::SORTED)
-                        .long("sorted")
-                        .short('s')
-                        .action(ArgAction::SetTrue)
-                        .help(about::QUERY_SORTED)
-                        .long_help(about::QUERY_SORTED_LONG),
                 ),
         )
         .subcommand(
@@ -245,7 +233,6 @@ mod arg {
     pub const PATH: &str = "path"; // --path flag to run in a different path than cwd.
     pub const SEARCH_STR: &str = "search string";
     pub const BASH_COMPLETE_WORDS: &str = "bash-complete-words";
-    pub const SORTED: &str = "sorted"; // --sorted flag for query command to sort results
 }
 
 mod about {
@@ -260,8 +247,6 @@ tags 'foo' and 'bar'.  More complex queries can be delimited using
 parentheses. For example: '(foo & bar) | !baz' will list all files
 that either have both 'foo' and 'bar' tags, or don't have the 'baz'
 tag.";
-    pub const QUERY_SORTED: &str = "Sort query results before outputting.";
-    pub const QUERY_SORTED_LONG: &str = "After applying the filter, sort all results alphabetically by filename before outputting them.";
     pub const SEARCH: &str = "Search all tags and descriptions for the given keywords";
     pub const SEARCH_STR: &str = "A string of keywords to search for.";
     pub const SEARCH_STR_LONG: &str = "Any file that contains any of the keywords in this string in either it's tags or description will included in the output.";

--- a/src/core.rs
+++ b/src/core.rs
@@ -213,7 +213,7 @@ pub fn clean(path: PathBuf) -> Result<(), Error> {
         valid.extend(globs.iter().enumerate().filter_map(|(i, f)| {
             if matcher.is_glob_matched(i) {
                 let mut tags: Vec<String> = f.tags.iter().map(|t| t.to_string()).collect();
-                tags.sort();
+                tags.sort_unstable();
                 tags.dedup();
                 Some(FileDataOwned {
                     glob: f.path.to_string(),
@@ -225,7 +225,7 @@ pub fn clean(path: PathBuf) -> Result<(), Error> {
             }
         }));
         // This should group files that share the same tags and desc
-        valid.sort_by(|a, b| match a.tags.cmp(&b.tags) {
+        valid.sort_unstable_by(|a, b| match a.tags.cmp(&b.tags) {
             std::cmp::Ordering::Less => std::cmp::Ordering::Less,
             std::cmp::Ordering::Equal => a.desc.cmp(&b.desc),
             std::cmp::Ordering::Greater => std::cmp::Ordering::Greater,
@@ -370,7 +370,7 @@ fn what_is_file(path: &Path) -> Result<String, Error> {
         }
     }
     // Remove duplicate tags.
-    outtags.sort();
+    outtags.sort_unstable();
     outtags.dedup();
     Ok(full_description(outtags, outdesc))
 }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -66,12 +66,15 @@ impl<T: TagData> Filter<T> {
 }
 
 impl Filter<usize> {
-    pub fn eval(&self, flags: &[bool]) -> bool {
+    pub fn eval<F>(&self, checker: &F) -> bool
+    where
+        F: Fn(usize) -> bool,
+    {
         match self {
-            Tag(ti) => *flags.get(*ti).unwrap_or(&false),
-            And(lhs, rhs) => lhs.eval(flags) && rhs.eval(flags),
-            Or(lhs, rhs) => lhs.eval(flags) || rhs.eval(flags),
-            Not(input) => !input.eval(flags),
+            Tag(ti) => checker(*ti),
+            And(lhs, rhs) => lhs.eval(checker) && rhs.eval(checker),
+            Or(lhs, rhs) => lhs.eval(checker) || rhs.eval(checker),
+            Not(input) => !input.eval(checker),
             FalseTag => false,
             TrueTag => true,
         }

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -250,9 +250,12 @@ impl InteractiveSession {
                         }
                         Command::Filter(filter) => {
                             self.filtered_indices.clear();
-                            self.filtered_indices.extend(
-                                (0..self.num_files()).filter(|i| filter.eval(self.table.flags(*i))),
-                            );
+                            self.filtered_indices
+                                .extend((0..self.num_files()).filter(|fi| {
+                                    filter.eval(&|ti| {
+                                        *self.table.flags(*fi).get(ti).unwrap_or(&false)
+                                    })
+                                }));
                             self.update_lists();
                             self.filter_str = filter.text(self.table.tags());
                             self.state = State::ListsUpdated;

--- a/src/query.rs
+++ b/src/query.rs
@@ -183,7 +183,8 @@ impl TagMaker<usize> for TagTable {
 /// Returns the number of files and the number of tags.
 pub fn count_files_tags(path: PathBuf) -> Result<(usize, usize), Error> {
     let mut matcher = GlobMatches::new();
-    let (mut allfiles, mut alltags) = (AHashSet::new(), AHashSet::new());
+    let mut alltags = AHashSet::new();
+    let mut numfiles = 0usize;
     let mut dir = DirTree::new(
         path,
         LoaderOptions::new(
@@ -223,20 +224,22 @@ pub fn count_files_tags(path: PathBuf) -> Result<(usize, usize), Error> {
                 }
                 // Collect all tracked files.
                 matcher.find_matches(files, &globs, false);
-                allfiles.extend(files.iter().enumerate().filter_map(|(fi, file)| {
-                    match matcher.matched_globs(fi).next() {
+                numfiles += files
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(fi, file)| match matcher.matched_globs(fi).next() {
                         Some(_) => {
                             let mut relpath = rel_dir_path.to_path_buf();
                             relpath.push(file.name());
                             Some(relpath)
                         }
                         None => None,
-                    }
-                }));
+                    })
+                    .count();
             }
         }
     }
-    Ok((allfiles.len(), alltags.len()))
+    Ok((numfiles, alltags.len()))
 }
 
 pub fn run_query(dirpath: PathBuf, filter: &str) -> Result<(), Error> {

--- a/src/query.rs
+++ b/src/query.rs
@@ -125,23 +125,23 @@ impl TagTable {
             }
             // Process all files in the directory.
             gmatcher.find_matches(files, &globs, false);
-            for (ci, child) in files.iter().enumerate() {
+            table.files.reserve(files.len());
+            for (fi, file) in files.iter().enumerate() {
                 filetags.clear();
-                let found = gmatcher.matched_globs(ci).fold(false, |_, gi| {
+                let found = gmatcher.matched_globs(fi).fold(false, |_, gi| {
                     filetags.extend(globs[gi].tags.iter().map(|t| t.to_string()));
                     true
                 });
                 if found {
                     filetags.extend(implicit_tags_str(
-                        child
-                            .name()
+                        file.name()
                             .to_str()
-                            .ok_or(Error::InvalidPath(child.name().into()))?,
+                            .ok_or(Error::InvalidPath(file.name().into()))?,
                     ));
                     table.add_file(
                         {
                             let mut relpath = rel_dir_path.to_path_buf();
-                            relpath.push(child.name());
+                            relpath.push(file.name());
                             relpath
                         },
                         &mut filetags,

--- a/src/query.rs
+++ b/src/query.rs
@@ -70,12 +70,12 @@ pub(crate) struct TagTable {
 
 impl TagTable {
     fn into_query(self, filter: Filter<usize>) -> impl Iterator<Item = PathBuf> {
-        self.table
-            .into_iter()
-            .filter_map(move |(path, flags)| match filter.eval(&flags) {
+        self.table.into_iter().filter_map(move |(path, flags)| {
+            match filter.eval(&|ti| *flags.get(ti).unwrap_or(&false)) {
                 true => Some(path),
                 false => None,
-            })
+            }
+        })
     }
 
     /// Create a new tag table by recursively traversing directories

--- a/src/query.rs
+++ b/src/query.rs
@@ -311,7 +311,7 @@ impl DenseTagTable {
         } = TagTable::from_dir(dirpath)?;
         let tags: Box<[String]> = {
             let mut pairs: Vec<_> = tag_indices.iter().collect();
-            pairs.sort_by(|(_t1, i1), (_t2, i2)| i1.cmp(i2));
+            pairs.sort_unstable_by(|(_t1, i1), (_t2, i2)| i1.cmp(i2));
             pairs.into_iter().map(|(t, _i)| t.clone()).collect()
         };
         let (files, flags) = {
@@ -319,7 +319,7 @@ impl DenseTagTable {
                 .into_iter()
                 .map(|(p1, f1)| (format!("{}", p1.display()), f1))
                 .collect();
-            pairs.sort_by(|(path1, _flags1), (path2, _flags2)| path1.cmp(path2));
+            pairs.sort_unstable_by(|(path1, _flags1), (path2, _flags2)| path1.cmp(path2));
             let (files, flags): (Vec<_>, Vec<_>) = pairs.into_iter().unzip();
             let mut dense = BoolTable::new(files.len(), tags.len());
             for (i, src) in flags.iter().enumerate() {

--- a/src/query.rs
+++ b/src/query.rs
@@ -114,15 +114,12 @@ impl TagTable {
                 MetaData::FailedToLoad(e) => return Err(e),
             };
             // Push directory tags.
-            for tag in tags
-                .iter()
-                .map(|t| t.to_string())
-                .chain(implicit_tags_str(get_filename_str(abs_dir_path)?))
-            {
-                inherited
-                    .tag_indices
-                    .push(Self::get_tag_index(tag, &mut table.tag_index));
-            }
+            inherited.tag_indices.extend(
+                tags.iter()
+                    .map(|t| t.to_string())
+                    .chain(implicit_tags_str(get_filename_str(abs_dir_path)?))
+                    .map(|tag| Self::get_tag_index(tag, &mut table.tag_index)),
+            );
             // Process all files in the directory.
             gmatcher.find_matches(files, &globs, false);
             table.files.reserve(files.len());

--- a/src/query.rs
+++ b/src/query.rs
@@ -251,17 +251,6 @@ pub fn run_query(dirpath: PathBuf, filter: &str) -> Result<(), Error> {
     Ok(())
 }
 
-pub fn run_query_sorted(dirpath: PathBuf, filter: &str) -> Result<(), Error> {
-    let table = TagTable::from_dir(dirpath)?;
-    let filter = Filter::<usize>::parse(filter, &table).map_err(Error::InvalidFilter)?;
-    let mut results: Box<[_]> = table.into_query(filter).collect();
-    results.sort_unstable();
-    for path in results {
-        println!("{}", path.display());
-    }
-    Ok(())
-}
-
 /// 2d array of bools.
 pub(crate) struct BoolTable {
     data: Box<[bool]>, // Cannot be resized by accident.

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -54,6 +54,10 @@ pub(crate) struct VisitedDir<'a> {
     pub(crate) metadata: MetaData<'a>,
 }
 
+fn is_ftag_file(file: &OsStr) -> bool {
+    file == OsStr::new(FTAG_FILE) || file == OsStr::new(FTAG_BACKUP_FILE)
+}
+
 impl DirTree {
     pub fn new(rootdir: PathBuf, options: LoaderOptions) -> Result<Self, Error> {
         if !rootdir.is_dir() {
@@ -99,30 +103,22 @@ impl DirTree {
                     let before = self.stack.len();
                     if let Ok(entries) = std::fs::read_dir(&self.abs_dir_path) {
                         for child in entries.flatten() {
-                            let cname = child.file_name();
-                            if cname == OsStr::new(FTAG_FILE)
-                                || cname == OsStr::new(FTAG_BACKUP_FILE)
-                            {
-                                continue;
-                            }
-                            match child.file_type() {
-                                Ok(ctype) => {
-                                    if ctype.is_dir() {
-                                        self.stack.push(DirEntry {
-                                            depth: depth + 1,
-                                            entry_type: DirEntryType::Dir,
-                                            name: cname,
-                                        });
-                                    } else if ctype.is_file() {
-                                        self.stack.push(DirEntry {
-                                            depth: depth + 1,
-                                            entry_type: DirEntryType::File,
-                                            name: cname,
-                                        });
-                                        numfiles += 1;
-                                    }
+                            match (child.file_name(), child.file_type()) {
+                                (cname, _) if is_ftag_file(&cname) => continue,
+                                (cname, Ok(ctype)) if ctype.is_dir() => self.stack.push(DirEntry {
+                                    depth: depth + 1,
+                                    entry_type: DirEntryType::Dir,
+                                    name: cname,
+                                }),
+                                (cname, Ok(ctype)) if ctype.is_file() => {
+                                    self.stack.push(DirEntry {
+                                        depth: depth + 1,
+                                        entry_type: DirEntryType::File,
+                                        name: cname,
+                                    });
+                                    numfiles += 1;
                                 }
-                                Err(_) => continue,
+                                _ => continue,
                             }
                         }
                     }

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -128,11 +128,13 @@ impl DirTree {
                     }
                     self.num_children = self.stack.len() - before;
                     // Sort the contents of this folder to move all the files to the end of the stack.
-                    self.stack[before..].sort_by(|a, b| match (a.entry_type, b.entry_type) {
-                        (DirEntryType::File, DirEntryType::File) => a.name.cmp(&b.name),
-                        (DirEntryType::File, DirEntryType::Dir) => std::cmp::Ordering::Greater,
-                        (DirEntryType::Dir, DirEntryType::File) => std::cmp::Ordering::Less,
-                        (DirEntryType::Dir, DirEntryType::Dir) => std::cmp::Ordering::Equal,
+                    self.stack[before..].sort_unstable_by(|a, b| {
+                        match (a.entry_type, b.entry_type) {
+                            (DirEntryType::File, DirEntryType::File) => a.name.cmp(&b.name),
+                            (DirEntryType::File, DirEntryType::Dir) => std::cmp::Ordering::Greater,
+                            (DirEntryType::Dir, DirEntryType::File) => std::cmp::Ordering::Less,
+                            (DirEntryType::Dir, DirEntryType::Dir) => std::cmp::Ordering::Equal,
+                        }
                     });
                     return Some(VisitedDir {
                         traverse_depth: depth,


### PR DESCRIPTION
So far, this PR improves the performance of the `query` command, and the `count` command. It also changes the design of the `TagTable` so it now prints the query results in the order of traversal of the directory tree, even without the `--sorted` flag. So this PR also removes the `--sorted` flag.