### PR TITLE
Faster queries and bug fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ftag"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["Ranjeeth Mahankali <ranjeethmahankali@gmail.com>"]
 description = "CLI tool for tagging and searching files. See README.md for more info."

--- a/src/core.rs
+++ b/src/core.rs
@@ -2,7 +2,7 @@ use crate::{
     filter::FilterParseError,
     load::{
         get_filename_str, get_ftag_backup_path, get_ftag_path, implicit_tags_str, DirData,
-        FileLoadingOptions, GlobData, GlobMatches, Loader, LoaderOptions,
+        FileLoadingOptions, GlobMatches, Loader, LoaderOptions,
     },
     walk::{DirTree, MetaData, VisitedDir},
 };
@@ -174,7 +174,7 @@ fn write_tags<T: AsRef<str>>(tags: &[T], w: &mut impl io::Write) -> Result<(), i
     Ok(())
 }
 
-fn write_desc<T: AsRef<str>>(desc: &Option<T>, w: &mut impl io::Write) -> Result<(), io::Error> {
+fn write_desc<T: AsRef<str>>(desc: Option<&T>, w: &mut impl io::Write) -> Result<(), io::Error> {
     if let Some(desc) = desc {
         writeln!(w, "[desc]\n{}", desc.as_ref())
     } else {
@@ -203,22 +203,26 @@ pub fn clean(path: PathBuf) -> Result<(), Error> {
         ..
     }) = dir.walk()
     {
-        let DirData { globs, desc, tags } = match metadata {
+        let data = match metadata {
             MetaData::Ok(d) => d,
             MetaData::NotFound => continue,
             MetaData::FailedToLoad(e) => return Err(e),
         };
-        matcher.find_matches(files, &globs, true);
+        matcher.find_matches(files, &data.globs, true);
         valid.clear();
-        valid.extend(globs.iter().enumerate().filter_map(|(i, f)| {
-            if matcher.is_glob_matched(i) {
-                let mut tags: Vec<String> = f.tags.iter().map(|t| t.to_string()).collect();
+        valid.extend(data.globs.iter().enumerate().filter_map(|(gi, g)| {
+            if matcher.is_glob_matched(gi) {
+                let mut tags: Vec<String> = g
+                    .tags(&data.alltags)
+                    .iter()
+                    .map(|t| t.to_string())
+                    .collect();
                 tags.sort_unstable();
                 tags.dedup();
                 Some(FileDataOwned {
-                    glob: f.path.to_string(),
+                    glob: g.path.to_string(),
                     tags,
-                    desc: f.desc.map(|d| d.to_string()),
+                    desc: g.desc.map(|d| d.to_string()),
                 })
             } else {
                 None
@@ -245,8 +249,9 @@ pub fn clean(path: PathBuf) -> Result<(), Error> {
                 .map_err(|_| Error::CannotWriteFile(fpath.clone()))?,
         );
         // Write directory data.
-        write_tags(&tags, &mut writer).map_err(|_| Error::CannotWriteFile(fpath.clone()))?;
-        write_desc(&desc, &mut writer).map_err(|_| Error::CannotWriteFile(fpath.clone()))?;
+        write_tags(data.tags(), &mut writer).map_err(|_| Error::CannotWriteFile(fpath.clone()))?;
+        write_desc(data.desc.as_ref(), &mut writer)
+            .map_err(|_| Error::CannotWriteFile(fpath.clone()))?;
         // Write out the file data in groups that share the same tags and description.
         if let Some(last) = valid // TODO: Try to simplify this by making better use of iterators.
             .drain(..)
@@ -265,7 +270,7 @@ pub fn clean(path: PathBuf) -> Result<(), Error> {
                         Some(current) => {
                             write_globs(&current.globs, &mut writer)?;
                             write_tags(&current.tags, &mut writer)?;
-                            write_desc(&current.desc, &mut writer)?;
+                            write_desc(current.desc.as_ref(), &mut writer)?;
                             Some(FileDataMultiple {
                                 globs: vec![file.glob],
                                 tags: file.tags,
@@ -287,7 +292,7 @@ pub fn clean(path: PathBuf) -> Result<(), Error> {
                 .map_err(|_| Error::CannotWriteFile(fpath.clone()))?;
             write_tags(&last.tags, &mut writer)
                 .map_err(|_| Error::CannotWriteFile(fpath.clone()))?;
-            write_desc(&last.desc, &mut writer)
+            write_desc(last.desc.as_ref(), &mut writer)
                 .map_err(|_| Error::CannotWriteFile(fpath.clone()))?;
         }
     }
@@ -335,14 +340,16 @@ fn what_is_file(path: &Path) -> Result<String, Error> {
             file_desc: true,
         },
     ));
-    let DirData { desc, tags, globs } = {
-        match get_ftag_path::<true>(path) {
-            Some(storepath) => loader.load(&storepath)?,
-            None => return Err(Error::InvalidPath(path.to_path_buf())),
-        }
+    let data = match get_ftag_path::<true>(path) {
+        Some(storepath) => loader.load(&storepath)?,
+        None => return Err(Error::InvalidPath(path.to_path_buf())),
     };
-    let mut outdesc = desc.unwrap_or("").to_string();
-    let mut outtags = tags.iter().map(|t| t.to_string()).collect::<Vec<_>>();
+    let mut outdesc = data.desc.unwrap_or("").to_string();
+    let mut outtags = data
+        .tags()
+        .iter()
+        .map(|t| t.to_string())
+        .collect::<Vec<_>>();
     if let Some(parent) = path.parent() {
         outtags.extend(implicit_tags_str(get_filename_str(parent)?));
     }
@@ -351,20 +358,15 @@ fn what_is_file(path: &Path) -> Result<String, Error> {
         .ok_or(Error::InvalidPath(path.to_path_buf()))?
         .to_str()
         .ok_or(Error::InvalidPath(path.to_path_buf()))?;
-    for GlobData {
-        path: pattern,
-        desc: fdesc,
-        tags: ftags,
-    } in globs
-    {
-        if glob_match(pattern, filenamestr) {
+    for g in data.globs {
+        if glob_match(g.path, filenamestr) {
             outtags.extend(
-                ftags
+                g.tags(&data.alltags)
                     .iter()
                     .map(|t| t.to_string())
                     .chain(implicit_tags_str(filenamestr)),
             );
-            if let Some(fdesc) = fdesc {
+            if let Some(fdesc) = g.desc {
                 outdesc = format!("{}\n{}", fdesc, outdesc);
             }
         }
@@ -379,14 +381,13 @@ fn what_is_file(path: &Path) -> Result<String, Error> {
 /// description.
 fn what_is_dir(path: &Path) -> Result<String, Error> {
     let mut loader = Loader::new(LoaderOptions::new(true, true, FileLoadingOptions::Skip));
-    let DirData { desc, tags, .. } = {
-        match get_ftag_path::<true>(path) {
-            Some(storepath) => loader.load(&storepath)?,
-            None => return Err(Error::InvalidPath(path.to_path_buf())),
-        }
+    let data = match get_ftag_path::<true>(path) {
+        Some(storepath) => loader.load(&storepath)?,
+        None => return Err(Error::InvalidPath(path.to_path_buf())),
     };
-    let desc = desc.unwrap_or("").to_string();
-    let tags = tags
+    let desc = data.desc.unwrap_or("").to_string();
+    let tags = data
+        .tags()
         .iter()
         .map(|t| t.to_string())
         .chain(implicit_tags_str(get_filename_str(path)?))
@@ -450,6 +451,7 @@ pub fn untracked_files(root: PathBuf) -> Result<Vec<PathBuf>, Error> {
 /// Recursively traverse the directories from `path` and get all tags.
 pub fn get_all_tags(path: PathBuf) -> Result<impl Iterator<Item = String>, Error> {
     let mut alltags = AHashSet::new();
+    let mut matcher = GlobMatches::new();
     let mut dir = DirTree::new(
         path,
         LoaderOptions::new(
@@ -464,26 +466,31 @@ pub fn get_all_tags(path: PathBuf) -> Result<impl Iterator<Item = String>, Error
     while let Some(VisitedDir {
         abs_dir_path,
         metadata,
+        files,
         ..
     }) = dir.walk()
     {
         match metadata {
             MetaData::FailedToLoad(e) => return Err(e), // Bail out with error.
-            MetaData::Ok(DirData { tags, globs, .. }) => {
+            MetaData::Ok(DirData {
+                alltags: tags,
+                globs,
+                ..
+            }) => {
                 alltags.extend(
                     tags.into_iter()
                         .map(|t| t.to_string())
                         .chain(implicit_tags_str(get_filename_str(abs_dir_path)?)),
                 );
-                for fdata in globs.into_iter() {
-                    alltags.extend(
-                        fdata
-                            .tags
-                            .into_iter()
-                            .map(|t| t.to_string())
-                            .chain(implicit_tags_str(fdata.path)),
-                    );
-                }
+                matcher.find_matches(&files, &globs, false);
+                alltags.extend(
+                    files
+                        .iter()
+                        .enumerate()
+                        .filter(|(fi, _f)| matcher.is_file_matched(*fi))
+                        .filter_map(|(_fi, f)| f.name().to_str())
+                        .flat_map(|name| implicit_tags_str(name)),
+                );
             }
             MetaData::NotFound => continue, // No metadata, just pass on the tags to the next dir.
         }
@@ -528,11 +535,11 @@ pub fn search(path: PathBuf, needle: &str) -> Result<(), Error> {
     while let Some(VisitedDir { metadata, .. }) = dir.walk() {
         match metadata {
             MetaData::FailedToLoad(e) => return Err(e),
-            MetaData::Ok(DirData { tags, globs, desc }) => {
-                let dirmatch = match_desc(&words, &tags, desc);
-                for filepath in globs.iter().filter_map(|f| {
-                    if dirmatch || match_desc(&words, &f.tags, f.desc) {
-                        Some(f.path)
+            MetaData::Ok(data) => {
+                let dirmatch = match_desc(&words, data.tags(), data.desc);
+                for filepath in data.globs.iter().filter_map(|g| {
+                    if dirmatch || match_desc(&words, g.tags(&data.alltags), g.desc) {
+                        Some(g.path)
                     } else {
                         None
                     }

--- a/src/core.rs
+++ b/src/core.rs
@@ -175,10 +175,9 @@ fn write_tags<T: AsRef<str>>(tags: &[T], w: &mut impl io::Write) -> Result<(), i
 }
 
 fn write_desc<T: AsRef<str>>(desc: Option<&T>, w: &mut impl io::Write) -> Result<(), io::Error> {
-    if let Some(desc) = desc {
-        writeln!(w, "[desc]\n{}", desc.as_ref())
-    } else {
-        Ok(())
+    match desc {
+        Some(desc) => writeln!(w, "[desc]\n{}", desc.as_ref()),
+        None => Ok(()),
     }
 }
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -481,14 +481,14 @@ pub fn get_all_tags(path: PathBuf) -> Result<impl Iterator<Item = String>, Error
                         .map(|t| t.to_string())
                         .chain(implicit_tags_str(get_filename_str(abs_dir_path)?)),
                 );
-                matcher.find_matches(&files, &globs, false);
+                matcher.find_matches(files, &globs, false);
                 alltags.extend(
                     files
                         .iter()
                         .enumerate()
                         .filter(|(fi, _f)| matcher.is_file_matched(*fi))
                         .filter_map(|(_fi, f)| f.name().to_str())
-                        .flat_map(|name| implicit_tags_str(name)),
+                        .flat_map(implicit_tags_str),
                 );
             }
             MetaData::NotFound => continue, // No metadata, just pass on the tags to the next dir.

--- a/src/load.rs
+++ b/src/load.rs
@@ -399,7 +399,7 @@ impl Loader {
                         if self.options.include_file_tags() {
                             let (globs, tags, _desc) = file;
                             if tags.is_empty() {
-                                tags.extend(content.split_whitespace().map(|w| w.trim()));
+                                tags.extend(content.split_whitespace());
                             } else {
                                 return Err(Error::CannotParseFtagFile(
                                     filepath.to_path_buf(),
@@ -412,7 +412,7 @@ impl Loader {
                         }
                     } else if self.options.dir_tags {
                         if tags.is_empty() {
-                            tags.extend(content.split_whitespace().map(|w| w.trim()));
+                            tags.extend(content.split_whitespace());
                         } else {
                             return Err(Error::CannotParseFtagFile(
                                 filepath.to_path_buf(),

--- a/src/load.rs
+++ b/src/load.rs
@@ -402,7 +402,7 @@ impl Loader {
                     let globiter = content.lines().map(|l| l.trim());
                     match current_unit.as_mut() {
                         Some((globs, tags, desc)) => {
-                            let desc = std::mem::replace(desc, None);
+                            let desc = desc.take();
                             let tags = std::mem::replace(tags, 0..0);
                             for g in globs.drain(..) {
                                 files.push(GlobData {

--- a/src/query.rs
+++ b/src/query.rs
@@ -153,7 +153,7 @@ impl TagTable {
 
     fn get_tag_index(tag: String, map: &mut AHashMap<String, usize>) -> usize {
         let size = map.len();
-        *(map.entry(tag.to_string()).or_insert(size))
+        *(map.entry(tag).or_insert(size))
     }
 
     fn add_file(&mut self, path: PathBuf, tags: &mut Vec<String>, inherited: &[usize]) {

--- a/src/query.rs
+++ b/src/query.rs
@@ -219,10 +219,9 @@ pub fn count_files_tags(path: PathBuf) -> Result<(usize, usize), Error> {
                 files.iter().enumerate().fold(0usize, |numfiles, (fi, f)| {
                     match matcher.is_file_matched(fi) {
                         true => {
-                            match f.name().to_str() {
-                                Some(name) => alltags.extend(implicit_tags_str(name)),
-                                None => {}
-                            };
+                            if let Some(name) = f.name().to_str() {
+                                alltags.extend(implicit_tags_str(name));
+                            }
                             numfiles + 1
                         }
                         false => numfiles,

--- a/src/query.rs
+++ b/src/query.rs
@@ -159,7 +159,6 @@ impl TagTable {
     fn add_file(&mut self, path: PathBuf, tags: &mut Vec<String>, inherited: &[usize]) {
         let fi = self.files.len();
         self.files.push(path);
-
         self.table.extend(
             tags.drain(..)
                 .map(|tag| (fi, Self::get_tag_index(tag, &mut self.tag_index))) // This file's explicit tags.


### PR DESCRIPTION
The query code path is now fine tuned enough that the unintentional string copy in `get_tag_index` accounts for about 5% performance difference. This PR avoids that copy and improves the performance by 5%.